### PR TITLE
Keep track of subsurfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Feature *non-goals* include:
 
 ## Building dwl
 
-dwl has only two dependencies: wlroots 0.12 and wayland-protocols. Simply install these and run `make`.
+dwl has only two dependencies: wlroots-git and wayland-protocols. Simply install these and run `make`.
 
 To enable XWayland, you should also install xorg-xwayland and uncomment its flag in `config.mk`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dwl is a compact, hackable compositor for Wayland based on [wlroots](https://git
 
 dwl is not meant to provide every feature under the sun. Instead, like dwm, it sticks to features which are necessary, simple, and straightforward to implement given the base on which it is built. Implemented default features are:
 
-- Any features provided by dwm/Xlib: simple window borders, tags, keybindings, client rules, mouse move/resize. The built-in status bar is an exception to avoid taking a dependency on FreeType or Pango and increasing the SLOC
+- Any features provided by dwm/Xlib: simple window borders, tags, keybindings, client rules, mouse move/resize. Providing a built-in status bar is an exception to this goal, to avoid dependencies on font rendering and/or drawing libraries when an external bar could work well.
 - Configurable multi-monitor layout support, including position and rotation
 - Configurable HiDPI/multi-DPI support
 - Various Wayland protocols
@@ -21,7 +21,7 @@ dwl is not meant to provide every feature under the sun. Instead, like dwm, it s
 Features under consideration (possibly as patches) are:
 
 - Protocols made trivial by wlroots
-- Communication from the compositor to status bars.  A straightforward possibility would be to use stdout or a provided file descriptor.
+- Provide information to external status bars via stdout or another file descriptor
 - Implement the input-inhibitor protocol to support screen lockers
 - Implement the idle-inhibit protocol which lets applications such as mpv disable idle monitoring
 - Layer shell popups (used by Waybar)

--- a/config.def.h
+++ b/config.def.h
@@ -49,7 +49,7 @@ static const int repeat_delay = 600;
 
 /* Trackpad */
 static const int tap_to_click = 1;
-static const int natural_scrolling = 1;
+static const int natural_scrolling = 0;
 
 #define MODKEY WLR_MODIFIER_ALT
 #define TAGKEYS(KEY,SKEY,TAG) \

--- a/config.def.h
+++ b/config.def.h
@@ -101,6 +101,8 @@ static const Key keys[] = {
 	TAGKEYS(          XKB_KEY_8, XKB_KEY_asterisk,                   7),
 	TAGKEYS(          XKB_KEY_9, XKB_KEY_parenleft,                  8),
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_Q,          quit,           {0} },
+
+	/* Ctrl-Alt-Backspace and Ctrl-Alt-Fx used to be handled by X server */
 	{ WLR_MODIFIER_CTRL|WLR_MODIFIER_ALT,XKB_KEY_Terminate_Server, quit, {0} },
 #define CHVT(n) { WLR_MODIFIER_CTRL|WLR_MODIFIER_ALT,XKB_KEY_XF86Switch_VT_##n, chvt, {.ui = (n)} }
 	CHVT(1), CHVT(2), CHVT(3), CHVT(4), CHVT(5), CHVT(6),

--- a/config.def.h
+++ b/config.def.h
@@ -62,11 +62,13 @@ static const int natural_scrolling = 0;
 #define SHCMD(cmd) { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
 
 /* commands */
-static const char *termcmd[]  = { "alacritty", NULL };
+static const char *termcmd[] = { "alacritty", NULL };
+static const char *menucmd[] = { "bemenu-run", NULL };
 
 static const Key keys[] = {
 	/* Note that Shift changes certain key codes: c -> C, 2 -> at, etc. */
 	/* modifier                  key                 function        argument */
+	{ MODKEY,                    XKB_p,              spawn,          {.v = menucmd} },
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_Return,     spawn,          {.v = termcmd} },
 	{ MODKEY,                    XKB_KEY_j,          focusstack,     {.i = +1} },
 	{ MODKEY,                    XKB_KEY_k,          focusstack,     {.i = -1} },

--- a/config.def.h
+++ b/config.def.h
@@ -68,7 +68,7 @@ static const char *menucmd[] = { "bemenu-run", NULL };
 static const Key keys[] = {
 	/* Note that Shift changes certain key codes: c -> C, 2 -> at, etc. */
 	/* modifier                  key                 function        argument */
-	{ MODKEY,                    XKB_p,              spawn,          {.v = menucmd} },
+	{ MODKEY,                    XKB_KEY_p,          spawn,          {.v = menucmd} },
 	{ MODKEY|WLR_MODIFIER_SHIFT, XKB_KEY_Return,     spawn,          {.v = termcmd} },
 	{ MODKEY,                    XKB_KEY_j,          focusstack,     {.i = +1} },
 	{ MODKEY,                    XKB_KEY_k,          focusstack,     {.i = -1} },

--- a/dwl.c
+++ b/dwl.c
@@ -278,7 +278,6 @@ static void setlayout(const Arg *arg);
 static void setmfact(const Arg *arg);
 static void setmon(Client *c, Monitor *m, unsigned int newtags);
 static void setup(void);
-static void sigchld(int unused);
 static void spawn(const Arg *arg);
 static void tag(const Arg *arg);
 static void tagmon(const Arg *arg);
@@ -1984,8 +1983,9 @@ setup(void)
 	 * clients from the Unix socket, manging Wayland globals, and so on. */
 	dpy = wl_display_create();
 
-	/* clean up child processes immediately */
-	sigchld(0);
+	/* Indicate explicitly to the OS that we are not interested in info
+	 * about child processes (per POSIX.1-2001) */
+	signal(SIGCHLD, SIG_IGN);
 
 	/* The backend is a wlroots feature which abstracts the underlying input and
 	 * output hardware. The autocreate option will choose the most suitable
@@ -2134,15 +2134,6 @@ setup(void)
 		fprintf(stderr, "failed to setup XWayland X server, continuing without it\n");
 	}
 #endif
-}
-
-void
-sigchld(int unused)
-{
-	if (signal(SIGCHLD, sigchld) == SIG_ERR)
-		EBARF("can't install SIGCHLD handler");
-	while (0 < waitpid(-1, NULL, WNOHANG))
-		;
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -1995,7 +1995,7 @@ setup(void)
 	 * backend uses the renderer, for example, to fall back to software cursors
 	 * if the backend does not support hardware cursors (some older GPUs
 	 * don't). */
-	if (!(backend = wlr_backend_autocreate(dpy, NULL)))
+	if (!(backend = wlr_backend_autocreate(dpy)))
 		BARF("couldn't create backend");
 
 	/* If we don't provide a renderer, autocreate makes a GLES2 renderer for us.

--- a/dwl.c
+++ b/dwl.c
@@ -1284,7 +1284,7 @@ keypress(struct wl_listener *listener, void *data)
 	wlr_idle_notify_activity(idle, seat);
 
 	/* On _press_, attempt to process a compositor keybinding. */
-	if (event->state == WLR_KEY_PRESSED)
+	if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
 		for (i = 0; i < nsyms; i++)
 			handled = keybinding(mods, syms[i]) || handled;
 

--- a/dwl.c
+++ b/dwl.c
@@ -122,7 +122,7 @@ typedef struct {
 	struct wl_listener unmap;
 	struct wl_listener destroy;
 	struct wlr_subsurface *subsurface;
-	Monitor *mon;
+	Client *c;
 } Subsurface;
 
 typedef struct {
@@ -811,7 +811,7 @@ void
 commitnotify_sub(struct wl_listener *listener, void *data)
 {
 	Subsurface *s = wl_container_of(listener, s, commit);
-	wlr_output_damage_add_whole(s->mon->damage);
+	wlr_output_damage_add_whole(s->c->mon->damage);
 }
 
 void
@@ -1070,7 +1070,7 @@ void
 destroynotify_sub(struct wl_listener *listener, void *data)
 {
 	Subsurface *s = wl_container_of(listener, s, destroy);
-	wlr_output_damage_add_whole(s->mon->damage);
+	wlr_output_damage_add_whole(s->c->mon->damage);
 	wl_list_remove(&s->commit.link);
 	wl_list_remove(&s->map.link);
 	wl_list_remove(&s->unmap.link);
@@ -1387,7 +1387,7 @@ void
 mapnotify_sub(struct wl_listener *listener, void *data)
 {
 	Subsurface *s = wl_container_of(listener, s, map);
-	wlr_output_damage_add_whole(s->mon->damage);
+	wlr_output_damage_add_whole(s->c->mon->damage);
 }
 
 
@@ -1568,9 +1568,8 @@ moveresize(const Arg *arg)
 void
 new_subnotify(struct wl_listener *listener, void *data) {
 	Subsurface *s = calloc(1, sizeof(Subsurface));
-	Client *c = wl_container_of(listener, c, new_sub);
+	s->c = wl_container_of(listener, s->c, new_sub);
 	s->subsurface = data;
-	s->mon = c->mon;
 
 	LISTEN(&s->subsurface->surface->events.commit, &s->commit, commitnotify_sub);
 	LISTEN(&s->subsurface->events.map, &s->map, mapnotify_sub);
@@ -2377,7 +2376,7 @@ void
 unmapnotify_sub(struct wl_listener *listener, void *data)
 {
 	Subsurface *s = wl_container_of(listener, s, unmap);
-	wlr_output_damage_add_whole(s->mon->damage);
+	wlr_output_damage_add_whole(s->c->mon->damage);
 }
 
 

--- a/dwl.c
+++ b/dwl.c
@@ -505,6 +505,7 @@ arrange(Monitor *m)
 	else if (m->fullscreenclient)
 		maximizeclient(m->fullscreenclient);
 	/* TODO recheck pointer focus here... or in resize()? */
+	wlr_output_damage_add_whole(m->damage);
 }
 
 void
@@ -2028,7 +2029,6 @@ setmon(Client *c, Monitor *m, unsigned int newtags)
 	if (oldmon) {
 		wlr_surface_send_leave(client_surface(c), oldmon->wlr_output);
 		arrange(oldmon);
-		wlr_output_damage_add_whole(oldmon->damage);
 	}
 	if (m) {
 		/* Make sure window actually overlaps with the monitor */
@@ -2036,7 +2036,6 @@ setmon(Client *c, Monitor *m, unsigned int newtags)
 		wlr_surface_send_enter(client_surface(c), m->wlr_output);
 		c->tags = newtags ? newtags : m->tagset[m->seltags]; /* assign tags of target monitor */
 		arrange(m);
-		wlr_output_damage_add_whole(m->damage);
 	}
 	focusclient(focustop(selmon), 1);
 }


### PR DESCRIPTION
Fixes this [problem](https://github.com/djpohly/dwl/pull/87#issuecomment-794464789). Thanks for the hint.
Turns out applications like firefox use subsurfaces, which we were not keeping track of.